### PR TITLE
Fix for adding js_cols.require script dynamically

### DIFF
--- a/js_cols/base.js
+++ b/js_cols/base.js
@@ -293,15 +293,18 @@ js_cols.addDependency = function(relPath, provides, requires) {
    * @private
    */
   js_cols.writeScriptTag_ = function(src) {
-    if (js_cols.inHtmlDocument_()) {
-      var doc = js_cols.global.document;
-      doc.write(
-          '<script type="text/javascript" src="' + src + '"></' + 'script>');
-      return true;
-    } else {
-      return false;
-    }
-  };
+	    if (js_cols.inHtmlDocument_()) {
+	      var doc = js_cols.global.document;
+	      var script = doc.createElement('script');
+			script.type = 'text/javascript';
+			script.src = src;
+			document.getElementsByTagName('head')[0]
+					.appendChild(script);
+	      return true;
+	    } else {
+	      return false;
+	    }
+	  };
 /**
    * Looks at the dependency rules and tries to determine the script file that
    * fulfills a particular rule.


### PR DESCRIPTION
If you dynamically add a script tag that calls js_cols.require() your left with a new document that contains only the new script tag.  This is because if the
document has already loaded, document.write will create a new document
instead of referring to the current one.  I changed one of the methods to avoid using
document.write to add the script and this seems to solves the problem.
